### PR TITLE
Added RapidJSON as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rapidJSON"]
+	path = rapidJSON
+	url = https://github.com/miloyip/rapidjson.git


### PR DESCRIPTION
Apparently GitHub has this awesome feature where you can use a 'submodule' meaning that it will automatically update all the code from rapidJSON library github into the folder you are using effectively copying it into the directory.
#Also you need to add me as a contributer